### PR TITLE
Add truncate() function to clear database values

### DIFF
--- a/shittydb.py
+++ b/shittydb.py
@@ -1,4 +1,4 @@
-import subprocess
+import subprocess, os, re
 from codecs import encode
 
 # init() does some really important things to initialise shittydb.
@@ -117,3 +117,19 @@ class ShittyDB(object):
     def __setitem__(self, key, value):
         return self.setter.set(key, value)
 
+    """
+    Clears all values from a ShittyDB database.
+    Returns:
+      True if operation was done successfully, False otherwise
+    """
+    def truncate(self):
+        fname_re = 'LICENSE|README\.md|.*\.py[co]?|.*\.gemspec|.*\.rb'
+        try:
+            for filename in os.listdir('.'):
+                if re.match(fname_re, filename) == None:
+                    if os.path.isfile(filename):
+                        os.unlink(filename)
+        except Exception, e:
+            raise Exception("[E4233][CRITICAL] HARD DRIVE ERROR DETECTED, HIT COMPUTER FOR FIXING")
+        finally:
+            return True

--- a/test.py
+++ b/test.py
@@ -3,3 +3,4 @@ from shittydb import *
 db = ShittyDB()
 db['foo'] = 'this is really proper'
 print db['foo']
+db.truncate()


### PR DESCRIPTION
The `TRUNCATE TABLE` command in SQL is incredibly useful for quickly removing data, as well as for reminding you whether you're on the test or production database.

With this in mind, I've added a `truncate()` function that will clear all values from a ShittyDB database. I've also added a unit test.

I've only done this for the Python version because I don't know Ruby. Sorrynotsorry.
