### PR TITLE
allow installing via npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,6 @@
+c/
+java/
+php/
+python/
+ruby/
+vb/

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "shittydb",
+  "version": "1.0.0",
+  "description": "A confoundingly fast key-value store",
+  "main": "nodejs/shittydb.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/theseoafs/shittydb.git"
+  },
+  "keywords": [
+    "shittydb",
+    "shitty",
+    "database",
+    "db",
+    "fast"
+  ],
+  "author": "theseoafs",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/theseoafs/shittydb/issues"
+  },
+  "homepage": "https://github.com/theseoafs/shittydb"
+}


### PR DESCRIPTION
- This is all you need to use `npm install theseoafs/shittydb`. Coincidentally, logging into npm and running `npm login && npm publish` is all you need to publish it in the repos. if you don't want to submit it yourself and don't mind me doing it, I'm happy to do so.
- You could have a shittier package.json by setting the version ridiculously high, adding keywords, and messing with the formatting, but I just let npm generate it for me.
- Also, I think shittydb deserves to have a website, even if it's just generating it from the README.md.
